### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -669,10 +669,10 @@ export class ReadableDiffer {
     common = Math.min(this._nLeadingCharacters(fromLine, '\t'),
                       this._nLeadingCharacters(toLine, '\t'));
     common = Math.min(common,
-                      this._nLeadingCharacters(fromTags.substr(0, common),
+                      this._nLeadingCharacters(fromTags.slice(0, common),
                                                ' '));
-    fromTags = fromTags.substr(common).replace(/\s*$/, '');
-    toTags = toTags.substr(common).replace(/\s*$/, '');
+    fromTags = fromTags.slice(common).replace(/\s*$/, '');
+    toTags = toTags.slice(common).replace(/\s*$/, '');
 
     result = this._tagDeleted([fromLine]);
     if (fromTags.length > 0) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.